### PR TITLE
Fix redirect uris not being handled correctly from client

### DIFF
--- a/backend/Handlers.go
+++ b/backend/Handlers.go
@@ -94,9 +94,11 @@ func GetPeople(w http.ResponseWriter, r *http.Request) {
 func VerifyUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	tempUserCode := params["code"]
+	redirectURI := r.URL.Query().Get("redirect_uri")
 	fmt.Println("[+] Recieved code: " + tempUserCode)
+	fmt.Println("[+] Recieved redirect_uri: " + redirectURI)
 
-	aTokenResp, err := ExchangeToken(tempUserCode)
+	aTokenResp, err := ExchangeToken(tempUserCode, redirectURI)
 	if err != nil {
 		respondWithError(w, FailedTokenExchange, err.Error())
 		fmt.Println("Sending failed token exchange error")

--- a/backend/UserManagement.go
+++ b/backend/UserManagement.go
@@ -96,7 +96,7 @@ type LiProfile struct {
 }
 
 // ExchangeToken does the auhentication using client code and secret
-func ExchangeToken(TempClientCode string) (ATokenResponse, error) {
+func ExchangeToken(TempClientCode string, RedirectURI string) (ATokenResponse, error) {
 
 	cid, found := os.LookupEnv("LI_CLIENT_ID")
 	if !found {
@@ -107,9 +107,13 @@ func ExchangeToken(TempClientCode string) (ATokenResponse, error) {
 		return ATokenResponse{}, errors.New("Unable to get client secret from env var")
 	}
 	ruri, found := os.LookupEnv("LI_REDIRECT_URI")
-	if !found {
-		return ATokenResponse{}, errors.New("Unable to get redirect uri from env var")
+	if found {
+		fmt.Println("[+] Using server env redirect uri")
+	} else {
+		fmt.Println("[+] Using client param redirect uri")
+		ruri = RedirectURI
 	}
+
 	code := url.QueryEscape(TempClientCode)
 	ruri = url.QueryEscape(ruri)
 	params := fmt.Sprintf("grant_type=authorization_code&code=%s&redirect_uri=%s&"+

--- a/client/app/screens/LoginScreen.js
+++ b/client/app/screens/LoginScreen.js
@@ -65,7 +65,8 @@ class LoginScreen extends React.Component {
     if (result.type === 'success') {
       this.setState({ isLoading: true });
 
-      const uri = `https://meetover.herokuapp.com/login/${result.params.code}`;
+      const uri = `https://meetover.herokuapp.com/login/${result.params.code}` +
+        `?redirect_uri=${encodeURIComponent(redirectUri)}`;
       const init = { method: 'POST' };
 
       const response = await fetch(uri, init);


### PR DESCRIPTION
# Major Changes
## Server
1. The `redirect_uri` is fetched from query params during user auth flow
2. If a server environmental variable exists for the `redirect_uri` it will always be used. Otherwise the value passed in by the client will be used.

## Client
1. The `redirect_uri` is now passed as part of the querystring to the server during auth flow (This will need to be modified before the production build)