### PR TITLE
Refresh firebase token

### DIFF
--- a/backend/Handlers.go
+++ b/backend/Handlers.go
@@ -33,7 +33,7 @@ type RefreshResponse struct {
 type ResponseCode int
 
 const (
-	Unauthorized				ResponseCode = 401
+	Unauthorized        ResponseCode = 401
 	FailedTokenExchange ResponseCode = 506
 	FailedDBCall        ResponseCode = 507
 	FailedProfileFetch  ResponseCode = 508

--- a/backend/Routes.go
+++ b/backend/Routes.go
@@ -35,7 +35,7 @@ var routes = Routes{
 	Route{
 		"Refresh",
 		"POST",
-		"/login/refresh/{accessToken}",
+		"/refreshtoken",
 		RefreshCustomToken,
 	},
 	Route{

--- a/backend/Routes.go
+++ b/backend/Routes.go
@@ -33,6 +33,12 @@ var routes = Routes{
 		VerifyUser,
 	},
 	Route{
+		"Refresh",
+		"POST",
+		"/login/refresh/{accessToken}",
+		RefreshCustomToken,
+	},
+	Route{
 		"LinkedIn Profile",
 		"GET",
 		"/userinfo/{accessToken}",

--- a/client/app/App.js
+++ b/client/app/App.js
@@ -63,7 +63,8 @@ export default class App extends React.Component {
         if (userProfileString) {
           const userProfile = JSON.parse(userProfileString);
           this.setState({ userProfile });
-          signInToFirebase(userProfile.firebaseCustomToken || '');
+          signInToFirebase(userProfile.firebaseCustomToken || '',
+            userProfile.token.access_token || '');
         }
       })
     ]);

--- a/client/app/actions/userActions.js
+++ b/client/app/actions/userActions.js
@@ -48,7 +48,7 @@ export const authenticateAndCreateProfile = () => (
 
       const response = await fetch(uri, init);
       const { profile, token, firebaseCustomToken } = await response.json();
-      const firebaseIdToken = await fetchIdToken(firebaseCustomToken, token.access_token)
+      const firebaseIdToken = await fetchIdToken(firebaseCustomToken)
         .catch(err => null);
 
       dispatch(createProfile({

--- a/client/app/actions/userActions.js
+++ b/client/app/actions/userActions.js
@@ -48,7 +48,7 @@ export const authenticateAndCreateProfile = () => (
 
       const response = await fetch(uri, init);
       const { profile, token, firebaseCustomToken } = await response.json();
-      const firebaseIdToken = await fetchIdToken(firebaseCustomToken)
+      const firebaseIdToken = await fetchIdToken(firebaseCustomToken, token.access_token)
         .catch(err => null);
 
       dispatch(createProfile({


### PR DESCRIPTION
On the client, the firebase custom token can expire. This means the client cannot get an id token from firebase with which to make requests. Before, you had to log in and out of the app to get a new custom token, but this PR creates a new endpoint to refresh the firebase custom token seamlessly.

When testing this PR, you'll need to run the backend on your local machine, so make sure to `go build` before you do so. Also, see the comment below regarding a line number change on the mobile app.