### PR TITLE
Implement InitUser + minor changes

### DIFF
--- a/backend/Handlers.go
+++ b/backend/Handlers.go
@@ -22,6 +22,7 @@ type AuthResponse struct {
 	Profile             Profile        `json:"profile"`
 	AccessToken         ATokenResponse `json:"token"`
 	FirebaseCustomToken string         `json:"firebaseCustomToken"`
+	UserExists          bool           `json:"userExists"`
 }
 
 // RefreshResponse - returned to the client during firebase custom token refresh
@@ -110,7 +111,7 @@ func VerifyUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Updates access token if user exists or adds a new User
-	err = InitUser(p, aTokenResp)
+	userExists, err := InitUser(p, aTokenResp)
 	if err != nil {
 		respondWithError(w, FailedUserInit, err.Error())
 		return
@@ -126,6 +127,7 @@ func VerifyUser(w http.ResponseWriter, r *http.Request) {
 	resp.AccessToken = aTokenResp
 	resp.Profile = p
 	resp.FirebaseCustomToken = customToken
+	resp.UserExists = userExists
 
 	json.NewEncoder(w).Encode(resp)
 }

--- a/backend/UserManagement.go
+++ b/backend/UserManagement.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,8 +23,8 @@ type ATokenResponse struct {
 	Expiry uint   `json:"expires_in"`
 }
 
-// LiProfile is the JSON object we get from the linkedin profile
-type LiProfile struct {
+// Profile is the JSON object we user to store our user data
+type Profile struct {
 	CurrentShare struct {
 		Attribution struct {
 			Share struct {
@@ -91,17 +92,18 @@ type LiProfile struct {
 			Title   string `json:"title"`
 		} `json:"values"`
 	} `json:"positions"`
-	Summary string `json:"summary"`
+	Summary       string `json:"summary"`
+	ShareLocation bool   `json:"shareLocation"`
+	Greeting      string `json:"greeting"`
 }
 
 // User is user on MeetOver
 type User struct {
-	ID           string         `json:"uid,omitempty"`
-	Location     *Geolocation   `json:"location,omitempty"`
-	AccessToken  ATokenResponse `json:"accessToken"`
-	LiProfile    LiProfile      `json:"li_profile"`
-	IsSearching  bool           `json:"profile"`
-	HelloMessage string         `json:"hello_message"` // TODO: ask user to fill this feild in account creation
+	ID          string         `json:"uid,omitempty"`
+	Location    *Geolocation   `json:"location,omitempty"`
+	AccessToken ATokenResponse `json:"accessToken"`
+	Profile     Profile        `json:"profile"`
+	IsSearching bool           `json:"isSearching"`
 }
 
 // people is the set of active users. Involved in matching or searching.
@@ -134,6 +136,9 @@ func ExchangeToken(TempClientCode string, RedirectURI string) (ATokenResponse, e
 
 	endpoint := "https://www.linkedin.com/oauth/v2/accessToken"
 	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer([]byte(params)))
+	if err != nil {
+		return ATokenResponse{}, errors.New("Unable to create LI API call")
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Host", "www.linkedin.com")
 
@@ -161,10 +166,10 @@ func ExchangeToken(TempClientCode string, RedirectURI string) (ATokenResponse, e
 	return ATokenResponse{}, errors.New("No access token returned from linkedIn API")
 }
 
-// GetLiProfile uses access token and REST call to get the user's linkedIn profile
-func GetLiProfile(AccessToken string) (LiProfile, error) {
+// GetProfile uses access token and REST call to get the user's linkedIn profile
+func GetProfile(AccessToken string) (Profile, error) {
 	// Fill the record with the data from the JSON
-	var record LiProfile
+	var record Profile
 	// QueryEscape escapes the parama
 	items := "(id,first-name,last-name,maiden-name,formatted-name,phonetic-first-name," +
 		"phonetic-last-name,formatted-phonetic-name,headline,location," +
@@ -175,14 +180,14 @@ func GetLiProfile(AccessToken string) (LiProfile, error) {
 	url := fmt.Sprintf("%s/v1/people/~:%s?oauth2_access_token=%s&format=json", LIAPI, items, ATokenQE)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return LiProfile{}, errors.New("Unable to form HTTP request")
+		return Profile{}, errors.New("Unable to form HTTP request")
 	}
 	// For control over HTTP client headers,redirect policy, and other settings,
 	client := &http.Client{}
 	// returns an HTTP response
 	resp, err := client.Do(req)
 	if err != nil {
-		return LiProfile{}, errors.New("Unable to make REST call to get profile data")
+		return Profile{}, errors.New("Unable to make REST call to get profile data")
 	}
 
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
@@ -190,28 +195,44 @@ func GetLiProfile(AccessToken string) (LiProfile, error) {
 	if err := json.Unmarshal(bodyBytes, &record); err != nil {
 		bodyString := string(bodyBytes)
 		fmt.Println(bodyString)
-		return LiProfile{}, errors.New("Unexpected Response Getting LI profile: " + bodyString)
+		return Profile{}, errors.New("Unexpected Response Getting LI profile: " + bodyString)
 	}
+
+	// Set initial profile values
+	record.ShareLocation = true
+
 	return record, nil
 }
 
 // InitUser Updates access token if user exists or adds a new User as user in firebase
-func InitUser(lip LiProfile, aTokenResp ATokenResponse) error {
-	users, err := fbClient.Ref("/users")
+func InitUser(p Profile, aTokenResp ATokenResponse) error {
+	// Check if token exists
+	tokenRef, err := fbClient.Ref("/users/" + p.ID + "/accessToken")
 	if err != nil {
 		fmt.Println("Failed to save user profile to Firebase in InitUser()")
 		return errors.New("Failed to save user profile: \n" + err.Error())
 	}
-	// TODO:  Check if User exists
-	// if no access token, create a new User
-	// if profile exists and token is expired, update access token and expiry
-	User := User{
-		ID:          lip.ID,
-		AccessToken: aTokenResp,
-		LiProfile:   lip,
+	token := ATokenResponse{}
+	if err := tokenRef.Value(&token); err != nil {
+		log.Fatalf("Could not get user in Firebase: %v\n", err)
 	}
-	addUser := make(map[string]interface{})
-	addUser[lip.ID] = User
-	defer users.Update(addUser)
+
+	// Update token or create new user
+	if token.AToken != "" {
+		defer tokenRef.Set(aTokenResp)
+	} else {
+		userRef, err := fbClient.Ref("/users/" + p.ID)
+		if err != nil {
+			fmt.Println("Failed to save user profile to Firebase in InitUser()")
+			return errors.New("Failed to save user profile: \n" + err.Error())
+		}
+
+		user := User{
+			ID:          p.ID,
+			AccessToken: aTokenResp,
+			Profile:     p,
+		}
+		defer userRef.Set(user)
+	}
 	return nil
 }

--- a/client/app/actions/matchesActions.js
+++ b/client/app/actions/matchesActions.js
@@ -1,4 +1,5 @@
 import { times } from 'lodash';
+import { serverURI } from '../constants/Common';
 
 import {
   FETCH_MATCHES,
@@ -22,7 +23,7 @@ export const fetchMatchesAsync = userId => {
     let matches;
 
     if (useMocks) {
-      const uri = 'https://meetover.herokuapp.com/test/liprofile';
+      const uri = `${serverURI}/test/profile`;
       const init = { method: 'POST' };
 
       const response = await fetch(uri, init);
@@ -31,7 +32,7 @@ export const fetchMatchesAsync = userId => {
 
       matches = times(10, () => Object.assign({}, profile));
     } else {
-      const uri = `https://meetover.herokuapp.com/match/${userId}`;
+      const uri = `${serverURI}/match/${userId}`;
       const init = { method: 'POST' };
 
       const response = await fetch(uri, init);
@@ -47,14 +48,14 @@ export const fetchProfileAsync = userId => {
     let profile;
 
     if (useMocks) {
-      const uri = 'https://meetover.herokuapp.com/test/liprofile';
+      const uri = `${serverURI}/test/profile`;
       const init = { method: 'POST' };
 
       const response = await fetch(uri, init);
       profile = await response.json();
       profile = JSON.parse(profile);
     } else {
-      const uri = `https://meetover.herokuapp.com/people/${userId}`;
+      const uri = `${serverURI}/people/${userId}`;
       const init = { method: 'GET' };
 
       const response = await fetch(uri, init);

--- a/client/app/actions/userActions.js
+++ b/client/app/actions/userActions.js
@@ -1,6 +1,7 @@
 import Expo, { AuthSession } from 'expo';
 import { LI_APP_ID } from 'react-native-dotenv';
 
+import { serverURI } from '../constants/Common';
 import { StyledToast } from '../helpers';
 import { fetchIdToken } from '../firebase';
 import {
@@ -42,7 +43,7 @@ export const authenticateAndCreateProfile = () => (
     });
 
     if (result.type === 'success') {
-      const uri = `https://meetover.herokuapp.com/login/${result.params.code}` +
+      const uri = `${serverURI}/login/${result.params.code}` +
         `?redirect_uri=${encodeURIComponent(redirectUri)}`;
       const init = { method: 'POST' };
 

--- a/client/app/actions/userActions.js
+++ b/client/app/actions/userActions.js
@@ -33,6 +33,7 @@ export const modifyProfile = (key, value) => ({
 
 export const authenticateAndCreateProfile = () => (
   async dispatch => {
+    let isAuthenticated = false;
     const redirectUri = AuthSession.getRedirectUrl();
     const result = await AuthSession.startAsync({
       authUrl:
@@ -48,19 +49,22 @@ export const authenticateAndCreateProfile = () => (
       const init = { method: 'POST' };
 
       const response = await fetch(uri, init);
-      const { profile, token, firebaseCustomToken } = await response.json();
+      const { profile, token, firebaseCustomToken, userExists } = await response.json();
       const firebaseIdToken = await fetchIdToken(firebaseCustomToken)
         .catch(err => null);
+
+      isAuthenticated = userExists;
 
       dispatch(createProfile({
         ...profile,
         token,
         firebaseCustomToken,
         firebaseIdToken,
+        isAuthenticated
       }));
     }
-    
-    return result.type;
+
+    return { type: result.type, isAuthenticated };
   }
 );
 

--- a/client/app/constants/Common.js
+++ b/client/app/constants/Common.js
@@ -1,0 +1,1 @@
+export const serverURI = 'https://meetover.herokuapp.com';

--- a/client/app/constants/Common.js
+++ b/client/app/constants/Common.js
@@ -1,1 +1,2 @@
 export const serverURI = 'https://meetover.herokuapp.com';
+export const chatMessagesToLoad = 50;

--- a/client/app/firebase/index.js
+++ b/client/app/firebase/index.js
@@ -33,9 +33,10 @@ export const signInToFirebase = async (token, accessToken, id) => {
 
     const response = await fetch(uri, init);
 
-    if (response.status === 401) {
+    if (response.status !== 200) {
       const err = 'Could not sign in to Firebase: invalid credentials';
       console.log(err);
+      console.log(response);
       throw err;
     }
 

--- a/client/app/firebase/index.js
+++ b/client/app/firebase/index.js
@@ -4,6 +4,8 @@ import 'firebase/database';
 
 import { FIREBASE_API_KEY, FIREBASE_SENDER_ID } from 'react-native-dotenv';
 
+import { serverURI } from '../constants/Common';
+
 const config = {
   apiKey: FIREBASE_API_KEY,
   authDomain: "meetoverdb.firebaseapp.com",
@@ -20,7 +22,7 @@ export const signInToFirebase = async (token, accessToken, id) => {
     await firebase.auth().signInWithCustomToken(token);
     return token;
   } catch (error) {
-    const uri = 'https://meetover.herokuapp.com/refreshtoken/';
+    const uri = `${serverURI}/refreshtoken`;
     const init = {
       method: 'POST',
       headers: new Headers({

--- a/client/app/screens/ChatScreen.js
+++ b/client/app/screens/ChatScreen.js
@@ -9,14 +9,13 @@ import {
 import { GiftedChat, Bubble } from 'react-native-gifted-chat';
 
 import { PTSansText } from '../components/StyledText';
+import { chatMessagesToLoad } from '../constants/Common';
 import Colors from '../constants/Colors';
 import { sendFirebaseMessage } from '../firebase';
 import {
   registerFetchNewMessageAsync,
   fetchEarlierMessagesAsync
 } from '../actions/chatActions';
-
-const messagesToLoad = 50;
 
 class ChatScreen extends React.Component {
   static navigationOptions = ({ navigation }) => ({
@@ -37,7 +36,7 @@ class ChatScreen extends React.Component {
     } = this.props;
     const _id = navigation.state.params._id;
 
-    fetchEarlierMessagesAsync(_id, messagesToLoad, messages[messages.length - 1]._id);
+    fetchEarlierMessagesAsync(_id, chatMessagesToLoad, messages[messages.length - 1]._id);
   }
 
   renderBubble (props) {
@@ -85,7 +84,7 @@ class ChatScreen extends React.Component {
     } = this.props;
 
     if (!messages) {
-      fetchEarlierMessagesAsync(navigation.state.params._id, messagesToLoad);
+      fetchEarlierMessagesAsync(navigation.state.params._id, chatMessagesToLoad);
       registerFetchNewMessageAsync(navigation.state.params._id);
     }
   }

--- a/client/app/screens/LoginScreen.js
+++ b/client/app/screens/LoginScreen.js
@@ -51,9 +51,16 @@ class LoginScreen extends React.Component {
   _handleSignInPressAsync = async () => {
     const { authenticateAndCreateProfile, navigation } = this.props;
     this.setState({ isLoading: true });
-    const resultType = await authenticateAndCreateProfile();
+    const result = await authenticateAndCreateProfile();
     this.setState({ isLoading: false });
-    resultType === 'success' && navigation.navigate('CreateProfile');
+
+    if (result.type === 'success') {
+      if (result.isAuthenticated) {
+        navigation.navigate('App');
+      } else {
+        navigation.navigate('CreateProfile');
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Changes
1. `InitUser` now checks if the user profile is already created before updating the profile
1. Rename `liprofile` to `profile` (plus similar namings) per previous meetings
1. Added `Greeting` and `ShareLocation` fields to `Profile`
1. Added client constants for `ServerURI` and `chatMessagesToLoad`