### PR TITLE
Auth backdoor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Mobile application for iOS and Android used to connect busy professionals on the
     - `GET: /`
     - `POST: /login/<linkedin code>`
     - `POST: /test/<type of test>`
+    - `POST: /imitateuser/<user id>`
 - Authenticated
     - `POST: /refreshtoken`
     - `POST: /meetover/<other user id>`

--- a/backend/router/Routes.go
+++ b/backend/router/Routes.go
@@ -43,6 +43,12 @@ var routes = Routes{
 		handlers.InitiateMeetover,
 	},
 	Route{
+		"Imitate User",
+		"POST",
+		"/imitateuser/{uid}",
+		handlers.ImitateUser,
+	},
+	Route{
 		"Processes the user's decision to MeetOver",
 		"POST",
 		"/meetover/decision/{otherID}",

--- a/backend/router/handlers/ImitateUser.go
+++ b/backend/router/handlers/ImitateUser.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"encoding/json"
+	"meetover/backend/firebase"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+const allowImitate = true
+
+// ImitateUser allows someone to sign in to an existing user for demo purposes
+func ImitateUser(w http.ResponseWriter, r *http.Request) {
+	if allowImitate {
+		params := mux.Vars(r)
+		uid := params["uid"]
+
+		imitate, err := firebase.GetUser(uid)
+		if err != nil {
+			respondWithError(w, FailedDBCall, "Error fetching user "+uid+" from Firebase for imitation.")
+			return
+		}
+
+		customToken, err := firebase.CreateCustomToken(uid)
+		if err != nil {
+			respondWithError(w, FailedTokenExchange, err.Error())
+			return
+		}
+
+		resp := AuthResponse{
+			AccessToken:         imitate.AccessToken,
+			Profile:             imitate.Profile,
+			FirebaseCustomToken: customToken,
+			UserExists:          true,
+		}
+
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	respondWithError(w, Unauthorized, "User imitation disabled")
+}

--- a/backend/router/handlers/ImitateUser.go
+++ b/backend/router/handlers/ImitateUser.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const allowImitate = true
+const allowImitate = false
 
 // ImitateUser allows someone to sign in to an existing user for demo purposes
 func ImitateUser(w http.ResponseWriter, r *http.Request) {

--- a/backend/router/handlers/VerifyUser.go
+++ b/backend/router/handlers/VerifyUser.go
@@ -45,11 +45,13 @@ func VerifyUser(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, FailedTokenExchange, err.Error())
 		return
 	}
-	var resp AuthResponse
-	resp.AccessToken = aTokenResp
-	resp.Profile = p
-	resp.FirebaseCustomToken = customToken
-	resp.UserExists = userExists
+
+	resp := AuthResponse{
+		AccessToken:         aTokenResp,
+		Profile:             p,
+		FirebaseCustomToken: customToken,
+		UserExists:          userExists,
+	}
 
 	json.NewEncoder(w).Encode(resp)
 }

--- a/client/app/constants/Common.js
+++ b/client/app/constants/Common.js
@@ -1,4 +1,4 @@
 export const serverURI = 'https://meetover.herokuapp.com';
 export const chatMessagesToLoad = 50;
 export const separator = '|';
-export const allowImitate = true;
+export const allowImitate = false;

--- a/client/app/constants/Common.js
+++ b/client/app/constants/Common.js
@@ -1,3 +1,4 @@
 export const serverURI = 'https://meetover.herokuapp.com';
 export const chatMessagesToLoad = 50;
 export const separator = '|';
+export const allowImitate = true;

--- a/client/app/screens/LoginScreen.js
+++ b/client/app/screens/LoginScreen.js
@@ -1,12 +1,20 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { Button, View, Spinner } from 'native-base';
+import {
+  Button,
+  Form,
+  Input,
+  Item,
+  Spinner,
+  View,
+} from 'native-base';
 
 import { connect } from 'react-redux';
 
 import Colors from '../constants/Colors';
 import { PTSansText } from '../components/StyledText';
-import { authenticateAndCreateProfile } from '../actions/userActions';
+import { authenticateAndCreateProfile, imitateUser } from '../actions/userActions';
+import { allowImitate } from '../constants/Common';
 
 class LoginScreen extends React.Component {
   static navigationOptions = {
@@ -14,7 +22,30 @@ class LoginScreen extends React.Component {
   };
 
   state = {
-    isLoading: false
+    isLoading: false,
+    imitateUID: '',
+  }
+
+  _renderImitateForm() {
+    if (allowImitate) {
+      return (
+        <Form>
+          <Item>
+            <Input placeholder='uid'
+              onChangeText={imitateUID => this.setState({ imitateUID })}
+            />
+            <Button
+              style={styles.button}
+              onPress={this._handleImitatePressAsync}
+            >
+              <PTSansText>Imitate</PTSansText>
+            </Button>
+          </Item>
+        </Form>
+      );
+    }
+
+    return null;
   }
 
   render() {
@@ -44,8 +75,20 @@ class LoginScreen extends React.Component {
             By signing in you accept our terms of service
           </PTSansText>
         </View>
+        {this._renderImitateForm()}
       </View>
     );
+  }
+
+  _handleImitatePressAsync = async () => {
+    const { imitateUID } = this.state;
+    const { imitateUser, navigation } = this.props;
+
+    this.setState({ isLoading: true });
+    await imitateUser(imitateUID);
+    this.setState({ isLoading: false });
+
+    navigation.navigate('App');
   }
 
   _handleSignInPressAsync = async () => {
@@ -65,7 +108,8 @@ class LoginScreen extends React.Component {
 }
 
 const mapDispatchToProps = {
-  authenticateAndCreateProfile
+  authenticateAndCreateProfile,
+  imitateUser
 };
 
 export default connect(

--- a/client/app/screens/LoginScreen.js
+++ b/client/app/screens/LoginScreen.js
@@ -31,7 +31,8 @@ class LoginScreen extends React.Component {
       return (
         <Form>
           <Item>
-            <Input placeholder='uid'
+            <Input
+              placeholder='uid'
               onChangeText={imitateUID => this.setState({ imitateUID })}
             />
             <Button


### PR DESCRIPTION
![scaled_screen1](https://user-images.githubusercontent.com/624279/38770464-806581d8-3fe1-11e8-9c16-0bdd49224ef1.png) ![scaled_screen2](https://user-images.githubusercontent.com/624279/38770463-8055d95e-3fe1-11e8-8283-e006ffd36e4f.png)

Adds a route, `POST /imitateuser/<user id>`, to imitate the user. This is necessarily an unauthenticated route, as its use case is to impersonate a user before logging in.

Adds a simple view to the login screen to paste the id of the user to imitate. The app should then be entirely usable from that user's perspective.

To control the use of this feature, I've add an `allowImitate` variable in both the backend and client. The reason I've opted to hard-code instead of using an environment variable is because this route provides functionality only intended to be used for demo purposes. I think the added hassle of making a code change is merited, as such a change should not be made lightly.

## Testing

To test this PR, you'll have to set `allowImitate = true` in `backend/router/handlers/ImitateUser.go` and `client/app/screens/LoginScreen.js`